### PR TITLE
fix: allow HttpFormData in NSHTTPXMLHttpRequest

### DIFF
--- a/src/angular/xhr.ts
+++ b/src/angular/xhr.ts
@@ -1,7 +1,7 @@
 import {XhrFactory } from "@angular/common/http";
 import {Injectable} from "@angular/core";
 import * as types from "@nativescript/core/utils/types";
-import { request } from "..";
+import { request, HTTPFormData } from "..";
 import { HttpRequestOptions, HttpResponse, Trace } from "@nativescript/core";
 
 namespace XMLHttpRequestResponseType {
@@ -261,7 +261,7 @@ export class NSHTTPXMLHttpRequest {
 
             // @ts-ignore
             this._options.content = Blob.InternalAccessor.getBuffer(data);
-        } else if (data instanceof ArrayBuffer) {
+        } else if (data instanceof ArrayBuffer || data instanceof HTTPFormData) {
             this._options.content = data;
         }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
If you use a custom HttpRequest for send an HttpFormData, the body is dropped
## What is the new behavior?
HttpFormData is correctly sent as the request content
