### PR TITLE
fix: strings values not working in `HTTPFormDataEntry` on iOS

### DIFF
--- a/src/http.ios.ts
+++ b/src/http.ios.ts
@@ -224,6 +224,9 @@ export function request(options: HttpRequestOptions): Promise<HttpResponse> {
                                 // @ts-ignore
                                 const buffer = new Uint8Array(Blob.InternalAccessor.getBuffer(value.data).buffer.slice(0) as ArrayBuffer);
                                 multipartFormData.addFileParameterNameFilenameContentType(NSData.dataWithData(buffer as any), key, filename, formDataPartMediaType);
+                            } else if (typeof value.data === "string") {
+                                const buffer = new TextEncoder().encode(value.data);
+                                multipartFormData.addFileParameterNameFilenameContentType(NSData.dataWithData(buffer as any), key, filename, formDataPartMediaType);
                             } else {
                                 // Support for native file objects.
                                 multipartFormData.addFileParameterNameFilenameContentType(value.data, key, filename, formDataPartMediaType);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`HTTPFormDataEntry` does not support string values on iOS. It fails with the error `Error: [__NSCFString enumerateByteRangesUsingBlock:]: unrecognized selector sent to instance 0x7fd7058bd800`

## What is the new behavior?
<!-- Describe the changes. -->

iOS now support string values on `HTTPFormDataEntry` the same way Android does.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## BREAKING CHANGES:

None as far as I know
