### PR TITLE
Fix(websocket): Do not crash app when a reserved close code is passed (Android)

### DIFF
--- a/src/websocket/index.android.ts
+++ b/src/websocket/index.android.ts
@@ -23,7 +23,19 @@ export class WebsocketConnection implements IWebsocketConnection {
     }
 
     close(code: number, reason: string) {
-        return this.nativeConnection.close(code, reason);
+        try {
+            if ((code >= 1004 && code <= 1006) || (code >= 1015 && code <= 2999)) {
+                console.warn(`Code ${code} is reserved and may not be used.`);
+                // Fall back to an accepted code. Otherwise, the error will be caught by try/catch, but the connection won't be closed.
+                // https://github.com/square/okhttp/blob/master/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/ws/WebSocketProtocol.kt#L146
+                // https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
+                code = 1000; 
+            }
+            return this.nativeConnection.close(code, reason);
+        } catch (error) {
+            console.error(error);
+            return false;
+        }
     }
 
     cancel() {

--- a/src/websocket/index.android.ts
+++ b/src/websocket/index.android.ts
@@ -29,7 +29,7 @@ export class WebsocketConnection implements IWebsocketConnection {
                 // Fall back to an accepted code. Otherwise, the error will be caught by try/catch, but the connection won't be closed.
                 // https://github.com/square/okhttp/blob/master/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/ws/WebSocketProtocol.kt#L146
                 // https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
-                code = 1000; 
+                code = 1001; 
             }
             return this.nativeConnection.close(code, reason);
         } catch (error) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
#### Android
The following line throws an error when the `code` argument passed to the `close` method is a reserved number. The plugin doesn't handle this error currently. And, the app crashes with an error similar to `Code 1005 is reserved and may not be used.`

https://github.com/square/okhttp/blob/master/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/ws/WebSocketProtocol.kt#L146

#### iOS
The app doesn't crash. `onClose` listener gets called with code `1001`.

## What is the new behavior?
#### Android
This update makes the plugin handle this error that otherwise crashes the app.

##### Added Try-Catch Block:
- Wrapped the close method's logic in a try-catch block to handle any errors that may occur during the execution of the method.

##### Reserved Close Code Check
- Implemented a check to identify if the provided code falls within reserved ranges ([1004-1006 or 1015-2999](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code)).
- Logs a warning if a reserved code is detected, ensuring developers are aware of its use.

##### Fallback to Standard Close Code:
- If a reserved code is used, the method falls back to the standard close code 1000, indicating a normal closure.
- This ensures the connection is closed gracefully, so the app can start retrying the connection.

#### iOS
Nothing changed.

